### PR TITLE
Area creation endpoint

### DIFF
--- a/server/init-mongo.js
+++ b/server/init-mongo.js
@@ -17,11 +17,9 @@ usersCollection.createIndex({ email: 1 }, { unique: true });
 const servicesCollection = db.services;
 servicesCollection.insertOne({
     name: "example_service",
-    actions: [
-        { id: 1, name: "example_action", description: "An example action" }
-    ],
+    actions: [{ name: "example_action", description: "An example action" }],
     reactions: [
-        { id: 1, name: "example_reaction", description: "An example reaction" }
+        { name: "example_reaction", description: "An example reaction" }
     ]
 });
 servicesCollection.createIndex({ name: 1 }, { unique: true });

--- a/server/src/routes/about.router.ts
+++ b/server/src/routes/about.router.ts
@@ -1,27 +1,6 @@
 import express from "express";
 import { db } from "../mongodb";
-import { ObjectId } from "mongodb";
-
-type ClientInfo = {
-    host: string;
-};
-
-type Service = {
-    _id: ObjectId;
-    name: string;
-    actions: { name: string; description: string }[];
-    reactions: { name: string; description: string }[];
-};
-
-type ServerInfo = {
-    current_time: number;
-    services: Service[];
-};
-
-type AboutInfo = {
-    client: ClientInfo;
-    server: ServerInfo;
-};
+import { Service, AboutInfo, ClientInfo, ServerInfo } from "../utils/db";
 
 function getClientInfo(req: express.Request): ClientInfo {
     return {
@@ -37,17 +16,12 @@ async function getServerInfo(): Promise<ServerInfo> {
 }
 
 async function getServices(): Promise<Service[]> {
-    const documents = await collection.find({}).toArray();
-    return documents.map((doc) => ({
-        _id: doc._id,
-        name: doc.name,
-        actions: doc.actions,
-        reactions: doc.reactions
-    }));
+    const documents = await services.find().toArray();
+    return documents;
 }
 
 const router = express.Router();
-const collection = db.collection("services");
+const services = db.collection<Service>("services");
 
 router.use("/", async (req, res) => {
     const aboutInfo: AboutInfo = {

--- a/server/src/routes/area.router.ts
+++ b/server/src/routes/area.router.ts
@@ -5,6 +5,7 @@ import { verifyToken } from "../utils/jwt";
 import { ObjectId } from "mongodb";
 import { isObjectId, objectExistsIn, Service } from "../utils/db";
 import { Area } from "../utils/db";
+import { validateJSONRequest } from "../utils/request.validation";
 
 const router = express.Router();
 
@@ -79,11 +80,18 @@ async function isValidArea(
             return null;
         }
     }
+    if (!validateJSONRequest(req, res)) return null;
+    const { actionOptions, reactionOptions } = req.body || {
+        actionOptions: undefined,
+        reactionOptions: undefined
+    };
     return {
         actionServiceId: new ObjectId(actionServiceId),
         actionName,
+        actionOptions,
         reactionServiceId: new ObjectId(reactionServiceId),
         reactionName,
+        reactionOptions,
         userId: userId,
         createdAt: new Date()
     };

--- a/server/src/routes/area.router.ts
+++ b/server/src/routes/area.router.ts
@@ -1,8 +1,9 @@
 import express from "express";
+import { Request, Response } from "express";
 import { db } from "../mongodb";
 import { verifyToken } from "../utils/jwt";
 import { ObjectId } from "mongodb";
-import { isObjectId } from "../utils/db";
+import { isObjectId, objectExistsIn } from "../utils/db";
 
 export type Area = {
     _id?: ObjectId;
@@ -16,36 +17,55 @@ export type Area = {
 
 const router = express.Router();
 
+function isValidArea(req: Request, res: Response): Area | null {
+    const actionServiceId = req.params.actionServiceId;
+    const actionName = req.params.actionName;
+    const reactionServiceId = req.params.reactionServiceId;
+    const reactionName = req.params.reactionName;
+    const userId = req.userId;
+    if (
+        !actionServiceId ||
+        !actionName ||
+        !reactionServiceId ||
+        !reactionName ||
+        !userId
+    ) {
+        res.status(400).json({
+            error: "Missing area data. Required: actionServiceId, actionName, reactionServiceId, reactionName, userId"
+        });
+        return null;
+    }
+    if (
+        isObjectId(actionServiceId) === false ||
+        isObjectId(reactionServiceId) === false ||
+        typeof actionName !== "string" ||
+        typeof reactionName !== "string"
+    ) {
+        res.status(400).json({
+            error: "Invalid area data types. Expected: actionServiceId (ObjectId), actionName (string), reactionServiceId (ObjectId), reactionName (string), userId (ObjectId)"
+        });
+        return null;
+    }
+    return {
+        actionServiceId: new ObjectId(actionServiceId),
+        actionName,
+        reactionServiceId: new ObjectId(reactionServiceId),
+        reactionName,
+        userId: userId,
+        createdAt: new Date()
+    };
+}
+
 router.post(
     "/:actionServiceId/:actionName/:reactionServiceId/:reactionName",
     verifyToken,
     async (req, res) => {
-        const actionServiceId = req.params.actionServiceId;
-        const actionName = req.params.actionName;
-        const reactionServiceId = req.params.reactionServiceId;
-        const reactionName = req.params.reactionName;
-        const userId = req.userId;
-        if (!userId) return res.status(401).json({ error: "Unauthorized" });
-        if (
-            !actionServiceId ||
-            !actionName ||
-            !reactionServiceId ||
-            !reactionName
-        )
-            return res.status(400).json({ error: "Missing parameters" });
-        if (isObjectId(actionServiceId) === false)
-            return res.status(400).json({ error: "Invalid actionServiceId" });
-        if (isObjectId(reactionServiceId) === false)
-            return res.status(400).json({ error: "Invalid reactionServiceId" });
+        const newArea = isValidArea(req, res);
+        if (newArea === null) return;
         try {
-            const result = await db.collection<Area>("areas").insertOne({
-                actionServiceId: new ObjectId(actionServiceId),
-                actionName,
-                reactionServiceId: new ObjectId(reactionServiceId),
-                reactionName,
-                userId,
-                createdAt: new Date()
-            });
+            const result = await db
+                .collection<Area>("areas")
+                .insertOne(newArea);
             return res
                 .status(201)
                 .json({ message: "Area created", areaId: result.insertedId });

--- a/server/src/routes/area.router.ts
+++ b/server/src/routes/area.router.ts
@@ -1,7 +1,8 @@
 import express from "express";
 import { db } from "../mongodb";
-import { isObjectId, verifyToken } from "../utils/jwt";
+import { verifyToken } from "../utils/jwt";
 import { ObjectId } from "mongodb";
+import { isObjectId } from "../utils/db";
 
 export type Area = {
     _id?: ObjectId;

--- a/server/src/routes/area.router.ts
+++ b/server/src/routes/area.router.ts
@@ -122,7 +122,7 @@ router.delete("/:areaId", verifyToken, async (req, res) => {
     const userId = req.userId;
     if (!userId) return res.status(401).json({ error: "Unauthorized" });
     if (!areaId) return res.status(400).json({ error: "Missing areaId" });
-    if (isObjectId(areaId) === false)
+    if (!isObjectId(areaId))
         return res.status(400).json({ error: "Invalid areaId" });
     const _id = new ObjectId(areaId);
     try {

--- a/server/src/routes/area.router.ts
+++ b/server/src/routes/area.router.ts
@@ -3,8 +3,7 @@ import { Request, Response } from "express";
 import { db } from "../mongodb";
 import { verifyToken } from "../utils/jwt";
 import { ObjectId } from "mongodb";
-import { isObjectId, objectExistsIn, Service } from "../utils/db";
-import { Area } from "../utils/db";
+import { isObjectId, objectExistsIn, Service, Area } from "../utils/db";
 import { validateJSONRequest } from "../utils/request.validation";
 
 const router = express.Router();

--- a/server/src/routes/area.router.ts
+++ b/server/src/routes/area.router.ts
@@ -1,0 +1,81 @@
+import express from "express";
+import { db } from "../mongodb";
+import { isObjectId, verifyToken } from "../utils/jwt";
+import { ObjectId } from "mongodb";
+
+export type Area = {
+    _id?: ObjectId;
+    actionServiceId: ObjectId;
+    actionName: string;
+    reactionServiceId: ObjectId;
+    reactionName: string;
+    userId: ObjectId;
+    createdAt: Date;
+};
+
+const router = express.Router();
+
+router.post(
+    "/:actionServiceId/:actionName/:reactionServiceId/:reactionName",
+    verifyToken,
+    async (req, res) => {
+        const actionServiceId = req.params.actionServiceId;
+        const actionName = req.params.actionName;
+        const reactionServiceId = req.params.reactionServiceId;
+        const reactionName = req.params.reactionName;
+        const userId = req.userId;
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        if (
+            !actionServiceId ||
+            !actionName ||
+            !reactionServiceId ||
+            !reactionName
+        )
+            return res.status(400).json({ error: "Missing parameters" });
+        if (isObjectId(actionServiceId) === false)
+            return res.status(400).json({ error: "Invalid actionServiceId" });
+        if (isObjectId(reactionServiceId) === false)
+            return res.status(400).json({ error: "Invalid reactionServiceId" });
+        try {
+            const result = await db.collection<Area>("areas").insertOne({
+                actionServiceId: new ObjectId(actionServiceId),
+                actionName,
+                reactionServiceId: new ObjectId(reactionServiceId),
+                reactionName,
+                userId,
+                createdAt: new Date()
+            });
+            return res
+                .status(201)
+                .json({ message: "Area created", areaId: result.insertedId });
+        } catch (error) {
+            console.error("Error creating area:", error);
+            return res.status(500).json({ error: "Server error" });
+        }
+    }
+);
+
+router.delete("/:areaId", verifyToken, async (req, res) => {
+    const areaId = req.params.areaId;
+    const userId = req.userId;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+    if (!areaId) return res.status(400).json({ error: "Missing areaId" });
+    if (isObjectId(areaId) === false)
+        return res.status(400).json({ error: "Invalid areaId" });
+    const _id = new ObjectId(areaId);
+    try {
+        const result = await db
+            .collection<Area>("areas")
+            .deleteOne({ _id, userId });
+        if (result.deletedCount === 0)
+            return res.status(404).json({
+                error: "Area not found or you do not have permission to delete it"
+            });
+        return res.status(200).json({ message: "Area deleted" });
+    } catch (error) {
+        console.error("Error deleting area:", error);
+        return res.status(500).json({ error: "Server error" });
+    }
+});
+
+export default router;

--- a/server/src/utils/db.ts
+++ b/server/src/utils/db.ts
@@ -16,8 +16,10 @@ export type Area = {
     _id?: ObjectId;
     actionServiceId: ObjectId;
     actionName: string;
+    actionOptions?: Record<string, unknown>;
     reactionServiceId: ObjectId;
     reactionName: string;
+    reactionOptions?: Record<string, unknown>;
     userId: ObjectId;
     createdAt: Date;
 };

--- a/server/src/utils/db.ts
+++ b/server/src/utils/db.ts
@@ -10,3 +10,19 @@ import { ObjectId } from "mongodb";
 export const isObjectId = (id: string): boolean => {
     return ObjectId.isValid(id) && String(new ObjectId(id)) === id;
 };
+
+/** Checks if an object with the given ID exists in the specified collection.
+ *
+ * @param collectionName - The name of the MongoDB collection.
+ * @param id - The ObjectId to check for existence.
+ * @returns A promise that resolves to true if the object exists, false otherwise.
+ */
+export const objectExistsIn = async (
+    collectionName: string,
+    id: ObjectId
+): Promise<boolean> => {
+    const resultDocument = await db
+        .collection(collectionName)
+        .findOne({ _id: id });
+    return resultDocument !== null;
+};

--- a/server/src/utils/db.ts
+++ b/server/src/utils/db.ts
@@ -1,0 +1,12 @@
+import { db } from "../mongodb";
+import { ObjectId } from "mongodb";
+
+/**
+ * Checks if a string is a valid MongoDB ObjectId.
+ *
+ * @param id - The string to check.
+ * @returns True if the string is a valid ObjectId, false otherwise.
+ */
+export const isObjectId = (id: string): boolean => {
+    return ObjectId.isValid(id) && String(new ObjectId(id)) === id;
+};

--- a/server/src/utils/db.ts
+++ b/server/src/utils/db.ts
@@ -1,6 +1,37 @@
 import { db } from "../mongodb";
 import { ObjectId } from "mongodb";
 
+export type ClientInfo = {
+    host: string;
+};
+
+export type Service = {
+    _id: ObjectId;
+    name: string;
+    actions: { name: string; description: string }[];
+    reactions: { name: string; description: string }[];
+};
+
+export type Area = {
+    _id?: ObjectId;
+    actionServiceId: ObjectId;
+    actionName: string;
+    reactionServiceId: ObjectId;
+    reactionName: string;
+    userId: ObjectId;
+    createdAt: Date;
+};
+
+export type ServerInfo = {
+    current_time: number;
+    services: Service[];
+};
+
+export type AboutInfo = {
+    client: ClientInfo;
+    server: ServerInfo;
+};
+
 /**
  * Checks if a string is a valid MongoDB ObjectId.
  *

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -24,16 +24,6 @@ export function generateToken(userId: ObjectId): string {
     return jwt.sign(payload, JWT_SECRET);
 }
 
-/**
- * Checks if a string is a valid MongoDB ObjectId.
- *
- * @param id - The string to check.
- * @returns True if the string is a valid ObjectId, false otherwise.
- */
-export function isObjectId(id: string): boolean {
-    return ObjectId.isValid(id) && String(new ObjectId(id)) === id;
-}
-
 function verifyTokenInternal(token: string): JwtPayload | null {
     try {
         const decoded = jwt.verify(token, JWT_SECRET);

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -24,10 +24,21 @@ export function generateToken(userId: ObjectId): string {
     return jwt.sign(payload, JWT_SECRET);
 }
 
+/**
+ * Checks if a string is a valid MongoDB ObjectId.
+ *
+ * @param id - The string to check.
+ * @returns True if the string is a valid ObjectId, false otherwise.
+ */
+export function isObjectId(id: string): boolean {
+    return ObjectId.isValid(id) && String(new ObjectId(id)) === id;
+}
+
 function verifyTokenInternal(token: string): JwtPayload | null {
     try {
         const decoded = jwt.verify(token, JWT_SECRET);
         if (typeof decoded === "string") return null;
+        if (!decoded.userId || !decoded.expiresAt) return null;
         return decoded as JwtPayload;
     } catch (err) {
         return null;


### PR DESCRIPTION
This pull request introduces a new `area` feature to the backend, enabling users to create and delete "areas" that connect actions and reactions between services. It also refactors type definitions for better code reuse, improves validation and error handling, and makes minor data model adjustments.

**New area feature:**

* Adds `server/src/routes/area.router.ts` to support creating and deleting "areas" with thorough validation, authentication, and error handling.
* Introduces the `Area` type and related helper functions for area validation in `server/src/utils/db.ts`.

**Type and validation improvements:**

* Moves shared type definitions (`Service`, `AboutInfo`, `ClientInfo`, `ServerInfo`) to `server/src/utils/db.ts` for reuse and imports them in `about.router.ts`. [[1]](diffhunk://#diff-d52fa5dd2299b0aae427eff83c9641821b2aa221e4beacb7bc0db72f6ff1ee40L3-R3) [[2]](diffhunk://#diff-e0a849e0b43515e61d213771ecc5b35d85bcbc31c95d7817c1854f12fb9d4df4R1-R61)
* Refactors service fetching logic in `about.router.ts` for type safety and consistency.

**Data model and validation fixes:**

* Removes the `id` field from `actions` and `reactions` in the initial service document in `init-mongo.js` to match the new type definition.
* Enhances JWT payload validation to ensure required fields are present.